### PR TITLE
Add to docker files build project settings

### DIFF
--- a/main-app/Dockerfile
+++ b/main-app/Dockerfile
@@ -1,6 +1,7 @@
 FROM maven:3.8.4-openjdk-17-slim AS build
 WORKDIR /app
 COPY pom.xml .
+RUN mvn dependency:go-offline
 COPY src/ src/
 RUN mvn clean install
 

--- a/main-app/Dockerfile
+++ b/main-app/Dockerfile
@@ -1,4 +1,10 @@
+FROM maven:3.8.4-openjdk-17-slim AS build
+WORKDIR /app
+COPY pom.xml .
+COPY src/ src/
+RUN mvn clean install
+
 FROM bellsoft/liberica-openjdk-alpine-musl:17
-ARG JAR_FILE=target/*.jar
-COPY ${JAR_FILE} app.jar
-ENTRYPOINT ["java","-jar","/app.jar"]
+WORKDIR /app
+COPY --from=build /app/target/*.jar app.jar
+ENTRYPOINT ["java", "-jar", "/app/app.jar"]

--- a/notification-app/Dockerfile
+++ b/notification-app/Dockerfile
@@ -1,6 +1,7 @@
 FROM maven:3.8.4-openjdk-17-slim AS build
 WORKDIR /app
 COPY pom.xml .
+RUN mvn dependency:go-offline
 COPY src/ src/
 RUN mvn clean install
 

--- a/notification-app/Dockerfile
+++ b/notification-app/Dockerfile
@@ -1,4 +1,10 @@
+FROM maven:3.8.4-openjdk-17-slim AS build
+WORKDIR /app
+COPY pom.xml .
+COPY src/ src/
+RUN mvn clean install
+
 FROM bellsoft/liberica-openjdk-alpine-musl:17
-ARG JAR_FILE=target/*.jar
-COPY ${JAR_FILE} app.jar
-ENTRYPOINT ["java","-jar","/app.jar"]
+WORKDIR /app
+COPY --from=build /app/target/*.jar app.jar
+ENTRYPOINT ["java", "-jar", "/app/app.jar"]

--- a/payment-app/Dockerfile
+++ b/payment-app/Dockerfile
@@ -1,6 +1,7 @@
 FROM maven:3.8.4-openjdk-17-slim AS build
 WORKDIR /app
 COPY pom.xml .
+RUN mvn dependency:go-offline
 COPY src/ src/
 RUN mvn clean install
 

--- a/payment-app/Dockerfile
+++ b/payment-app/Dockerfile
@@ -1,4 +1,10 @@
+FROM maven:3.8.4-openjdk-17-slim AS build
+WORKDIR /app
+COPY pom.xml .
+COPY src/ src/
+RUN mvn clean install
+
 FROM bellsoft/liberica-openjdk-alpine-musl:17
-ARG JAR_FILE=target/*.jar
-COPY ${JAR_FILE} app.jar
-ENTRYPOINT ["java","-jar","/app.jar"]
+WORKDIR /app
+COPY --from=build /app/target/*.jar app.jar
+ENTRYPOINT ["java", "-jar", "/app/app.jar"]


### PR DESCRIPTION
**Changes:**

- Build Stage:
  - Based on Maven 3.8.4 and OpenJDK 17 (maven:3.8.4-openjdk-17-slim).
  - Sets the working directory to `/app`.
  - Copies pom.xml and the entire `src/` directory.
  - Executes mvn clean install to build the project.

- Final Stage:
  - Switches to a lightweight OpenJDK 17 Alpine-based image(bellsoft/liberica-openjdk-alpine-musl:17).
  - Sets the working directory to `/app`.
  - Copies the JAR file from the build stage (`/app/target/*.jar`) to the current directory.
  - Configures the entry point to run the JAR file using `java -jar app.jar`.

Link for task: https://trello.com/c/PBogE3Xl/5-add-to-docker-files-build-project-settings